### PR TITLE
fix(updater): add daily rate-limit for update check msg

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1201,7 +1201,7 @@ dependencies = [
 
 [[package]]
 name = "ninja-linter"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "ninja-linter"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -769,7 +769,7 @@ dependencies = [
 
 [[package]]
 name = "ninja-linter"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "clap",
  "colored",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -558,7 +558,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -566,12 +565,6 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-io"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-sink"
@@ -592,10 +585,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-core",
- "futures-io",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -1517,9 +1507,7 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
- "futures-channel",
  "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,6 +99,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -182,6 +188,19 @@ name = "cfg_aliases"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link",
+]
 
 [[package]]
 name = "clap"
@@ -1194,6 +1213,7 @@ name = "ninja-linter"
 version = "0.8.3"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap",
  "colored",
  "crossterm 0.29.0",
@@ -1214,6 +1234,15 @@ name = "num-conv"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "num_threads"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,7 +1191,7 @@ dependencies = [
 
 [[package]]
 name = "ninja-linter"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ninja-linter"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 build = "build.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ninja-linter"
-version = "0.8.1"
+version = "0.8.2"
 edition = "2024"
 build = "build.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ serde_json = "1.0"
 crossterm = "0.29.0"
 ratatui = "0.29"
 dirs = "6.0"
-reqwest = { version = "0.13.4", features = ["json", "blocking"] }
+reqwest = { version = "0.13.4", features = ["json"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 anyhow = "1.0.103"
 self-replace = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ reqwest = { version = "0.13.4", features = ["json"] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 anyhow = "1.0.103"
 self-replace = "1"
+chrono = "0.4.45"
 
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ninja-linter"
-version = "0.7.3"
+version = "0.8.0"
 edition = "2024"
 build = "build.rs"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ninja-linter"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2024"
 build = "build.rs"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,13 +1,16 @@
+use chrono::{DateTime, Utc};
+use colored::Colorize;
 use serde::{Deserialize, Serialize};
 use std::fs;
 use std::io::{self, Write};
 use std::path::PathBuf;
-use colored::Colorize;
 
 #[derive(Serialize, Deserialize, Debug, Default)]
 pub struct Config {
     pub test_command: Option<String>,
     pub container_name: Option<String>,
+    #[serde(default)]
+    pub updated_check_at: String,
 }
 
 const CONFIG_DIR: &str = "ninja-linter";
@@ -49,7 +52,9 @@ impl Config {
         io::stdout().flush().unwrap();
 
         let mut input = String::new();
-        io::stdin().read_line(&mut input).expect("Failed to read line");
+        io::stdin()
+            .read_line(&mut input)
+            .expect("Failed to read line");
         let input = input.trim().to_string();
 
         self.test_command = Some(input.clone());
@@ -70,7 +75,9 @@ impl Config {
         io::stdout().flush().unwrap();
 
         let mut input = String::new();
-        io::stdin().read_line(&mut input).expect("Failed to read line");
+        io::stdin()
+            .read_line(&mut input)
+            .expect("Failed to read line");
         let input = input.trim().to_string();
 
         self.container_name = Some(input.clone());
@@ -79,6 +86,24 @@ impl Config {
         }
 
         input
+    }
+
+    pub fn set_updated_check_at(&mut self, uca: DateTime<Utc>) {
+        self.updated_check_at = uca.to_rfc3339();
+
+        if let Err(e) = self.save() {
+            eprint!("{}: {}", "Error saving file config".red(), e);
+        }
+    }
+
+    pub fn get_updated_check_at(&self) -> DateTime<Utc> {
+        DateTime::parse_from_rfc3339(&self.updated_check_at)
+            .unwrap()
+            .with_timezone(&Utc)
+    }
+
+    pub fn has_updated_check_at(&self) -> bool {
+        !self.updated_check_at.is_empty()
     }
 }
 
@@ -111,6 +136,7 @@ mod tests {
         let mut config = Config {
             container_name: Some("my_container".to_string()),
             test_command: None,
+            ..Config::default()
         };
         let name = config.get_or_set_container_name();
         assert_eq!(name, "my_container");
@@ -121,9 +147,13 @@ mod tests {
         let mut config = Config {
             container_name: Some("original_container".to_string()),
             test_command: None,
+            ..Config::default()
         };
         config.get_or_set_container_name();
-        assert_eq!(config.container_name, Some("original_container".to_string()));
+        assert_eq!(
+            config.container_name,
+            Some("original_container".to_string())
+        );
     }
 
     #[test]
@@ -131,6 +161,7 @@ mod tests {
         let config = Config {
             container_name: Some("ninja_symfony".to_string()),
             test_command: None,
+            ..Config::default()
         };
         let json = serde_json::to_string(&config).unwrap();
         assert!(json.contains("ninja_symfony"));
@@ -150,7 +181,10 @@ mod tests {
         let json = r#"{"test_command": "docker exec ninja_symfony bin/phpunit"}"#;
         let config: Config = serde_json::from_str(json).unwrap();
         assert!(config.container_name.is_none());
-        assert_eq!(config.test_command, Some("docker exec ninja_symfony bin/phpunit".to_string()));
+        assert_eq!(
+            config.test_command,
+            Some("docker exec ninja_symfony bin/phpunit".to_string())
+        );
     }
 
     #[test]
@@ -158,10 +192,87 @@ mod tests {
         let original = Config {
             container_name: Some("my_app_container".to_string()),
             test_command: Some("docker exec my_app bin/phpunit".to_string()),
+            ..Config::default()
         };
         let json = serde_json::to_string(&original).unwrap();
         let restored: Config = serde_json::from_str(&json).unwrap();
         assert_eq!(restored.container_name, original.container_name);
         assert_eq!(restored.test_command, original.test_command);
+    }
+
+    // --- updated_check_at ---
+
+    #[test]
+    fn test_config_default_updated_check_at_is_empty() {
+        let config = Config::default();
+        assert!(config.updated_check_at.is_empty());
+    }
+
+    #[test]
+    fn test_has_updated_check_at_false_when_empty() {
+        let config = Config::default();
+        assert!(!config.has_updated_check_at());
+    }
+
+    #[test]
+    fn test_has_updated_check_at_true_when_set() {
+        let config = Config {
+            updated_check_at: "2026-07-07T00:00:00+00:00".to_string(),
+            ..Config::default()
+        };
+        assert!(config.has_updated_check_at());
+    }
+
+    #[test]
+    fn test_set_updated_check_at_stores_rfc3339() {
+        let mut config = Config::default();
+        let dt: chrono::DateTime<Utc> = chrono::DateTime::from_timestamp(0, 0).unwrap();
+        config.updated_check_at = dt.to_rfc3339();
+        assert_eq!(config.updated_check_at, "1970-01-01T00:00:00+00:00");
+    }
+
+    #[test]
+    fn test_get_updated_check_at_roundtrips() {
+        let mut config = Config::default();
+        let dt: chrono::DateTime<Utc> = chrono::DateTime::from_timestamp(1_000_000, 0).unwrap();
+        config.updated_check_at = dt.to_rfc3339();
+        let parsed = config.get_updated_check_at();
+        assert_eq!(parsed, dt);
+    }
+
+    #[test]
+    fn test_config_serializes_updated_check_at() {
+        let config = Config {
+            updated_check_at: "2026-07-07T00:00:00+00:00".to_string(),
+            ..Config::default()
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(json.contains("updated_check_at"));
+        assert!(json.contains("2026-07-07T00:00:00+00:00"));
+    }
+
+    #[test]
+    fn test_config_deserializes_updated_check_at() {
+        let json = r#"{"test_command":null,"container_name":null,"updated_check_at":"2026-07-07T00:00:00+00:00"}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert_eq!(config.updated_check_at, "2026-07-07T00:00:00+00:00");
+    }
+
+    #[test]
+    fn test_config_backwards_compat_missing_updated_check_at() {
+        let json = r#"{"test_command":null,"container_name":"ninja_symfony"}"#;
+        let config: Config = serde_json::from_str(json).unwrap();
+        assert!(config.updated_check_at.is_empty());
+    }
+
+    #[test]
+    fn test_config_roundtrip_with_updated_check_at() {
+        let original = Config {
+            updated_check_at: "2026-07-07T12:30:00+00:00".to_string(),
+            ..Config::default()
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let restored: Config = serde_json::from_str(&json).unwrap();
+        assert_eq!(restored.updated_check_at, original.updated_check_at);
     }
 }

--- a/src/tui.rs
+++ b/src/tui.rs
@@ -212,9 +212,9 @@ fn render_output(frame: &mut Frame, app: &App, area: Rect) {
 fn render_hint(frame: &mut Frame, app: &App, area: Rect) {
     let text = if app.complete {
         if app.has_failure() {
-            "  ❌ Some tasks failed · ↑↓ select · q exit"
+            "  ❌ Some tasks failed · ↑↓ select · Enter full output · q exit"
         } else {
-            "  ✅ All tasks passed · ↑↓ select · q exit"
+            "  ✅ All tasks passed · ↑↓ select · Enter full output · q exit"
         }
     } else {
         "  Press q or Esc to exit early"
@@ -261,11 +261,14 @@ fn restore_terminal(terminal: &mut CrosstermTerminal) -> io::Result<()> {
 const TICK_RATE: Duration = Duration::from_millis(100);
 
 /// Drive the ratatui event loop until all tasks are done or the user exits.
+///
+/// Returns `(success, dump)` where `dump` is `Some(output)` when the user
+/// pressed Enter to view a task's full output outside the TUI.
 fn run_loop(
     terminal: &mut CrosstermTerminal,
     app: &mut App,
     rx: &mpsc::Receiver<TaskUpdate>,
-) -> io::Result<bool> {
+) -> io::Result<(bool, Option<String>)> {
     loop {
         while let Ok(update) = rx.try_recv() {
             app.apply(update);
@@ -288,7 +291,13 @@ fn run_loop(
             && key.kind == KeyEventKind::Press
         {
             match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => return Ok(!app.has_failure()),
+                KeyCode::Char('q') | KeyCode::Esc => {
+                    return Ok((!app.has_failure(), None));
+                }
+                KeyCode::Enter if app.complete => {
+                    let output = app.tasks[app.selected].output.clone();
+                    return Ok((!app.has_failure(), Some(output)));
+                }
                 KeyCode::Up if app.complete && app.selected > 0 => {
                     app.selected -= 1;
                 }
@@ -339,7 +348,21 @@ pub fn run_dashboard(
         eprintln!("Failed to restore terminal: {e}");
     }
 
-    result.unwrap_or(false)
+    match result {
+        Ok((success, Some(output))) => {
+            let label = &app.tasks[app.selected].label;
+            println!("\n─── {} output ───\n", label);
+            if output.trim().is_empty() {
+                println!("(no output captured)");
+            } else {
+                println!("{}", output.trim_end());
+            }
+            println!();
+            success
+        }
+        Ok((success, None)) => success,
+        Err(_) => false,
+    }
 }
 
 // ─── Tests ────────────────────────────────────────────────────────────────────

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -154,7 +154,7 @@ async fn download_to_temp(url: &str) -> Result<std::path::PathBuf> {
 // TODO: refactor this
 async fn start_updater(latest: &RepoRelease) {
     println!(
-        "New version available: {} → {}. can you update (y/o)",
+        "New version available: {} → {}. can you update (y/n)",
         env!("CARGO_PKG_VERSION"),
         latest.tag_name
     );

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -2,8 +2,26 @@ use std::io;
 use std::io::Write;
 
 use anyhow::{Context, Result, bail};
+use chrono::{Duration, Utc};
 // use colored::Colorize;
 use serde::Deserialize;
+
+use crate::config::Config;
+
+#[derive(Debug)]
+struct Updater {
+    config: Config,
+    can_show_msg: bool,
+}
+
+impl Updater {
+    pub fn new(config: Config, can_show: bool) -> Self {
+        Updater {
+            config,
+            can_show_msg: can_show,
+        }
+    }
+}
 
 #[derive(Deserialize, Debug)]
 struct RepoRelease {
@@ -167,6 +185,12 @@ async fn start_updater(latest: &RepoRelease) {
         buf
     });
 
+    let updater = save_timestap();
+
+    if !updater.can_show_msg {
+        return;
+    }
+
     if user_res.trim().to_lowercase() != "y" {
         return;
     }
@@ -198,6 +222,26 @@ async fn start_updater(latest: &RepoRelease) {
         "Ready: Ninja Linter updated to version: {}",
         &latest.tag_name
     );
+}
+
+fn save_timestap() -> Updater {
+    let config = Config::load();
+    let mut updater = Updater::new(config, false);
+
+    let now = Utc::now();
+    if !updater.config.has_updated_check_at() {
+        // First run — no cooldown stored yet, show immediately
+        updater.can_show_msg = true;
+        updater.config.set_updated_check_at(now + Duration::days(1));
+    } else {
+        let next_check = updater.config.get_updated_check_at();
+        if now >= next_check {
+            updater.can_show_msg = true;
+            updater.config.set_updated_check_at(now + Duration::days(1));
+        }
+    }
+
+    updater
 }
 
 // --------------- test ----------------------
@@ -326,6 +370,30 @@ mod tests {
         };
         let url = find_asset_url(&release).unwrap();
         assert_eq!(url, "https://example.com/correct");
+    }
+
+    // --- Updater ---
+
+    #[test]
+    fn test_updater_new_sets_can_show_true() {
+        let config = Config::default();
+        let updater = Updater::new(config, true);
+        assert!(updater.can_show_msg);
+    }
+
+    #[test]
+    fn test_updater_new_sets_can_show_false() {
+        let config = Config::default();
+        let updater = Updater::new(config, false);
+        assert!(!updater.can_show_msg);
+    }
+
+    #[test]
+    fn test_updater_new_stores_config() {
+        let mut config = Config::default();
+        config.updated_check_at = "2026-07-07 00:00:00 UTC".to_string();
+        let updater = Updater::new(config, false);
+        assert_eq!(updater.config.updated_check_at, "2026-07-07 00:00:00 UTC");
     }
 
     // --- JSON deserialization ---

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -30,8 +30,28 @@ pub async fn show_display_msg() {
         return;
     }
 
-    if current_version > latest_version.tag_name {
+    if is_newer(&latest_version.tag_name, &current_version) {
         start_updater(&latest_version);
+    }
+}
+
+fn parse_semver(v: &str) -> Option<(u64, u64, u64)> {
+    let s = v.trim_start_matches('v');
+    let parts: Vec<&str> = s.split('.').collect();
+    if parts.len() != 3 {
+        return None;
+    }
+    Some((
+        parts[0].parse().ok()?,
+        parts[1].parse().ok()?,
+        parts[2].parse().ok()?,
+    ))
+}
+
+fn is_newer(candidate: &str, baseline: &str) -> bool {
+    match (parse_semver(candidate), parse_semver(baseline)) {
+        (Some(c), Some(b)) => c > b,
+        _ => candidate > baseline,
     }
 }
 fn fetch_release(url: &str) -> Result<RepoRelease> {
@@ -181,6 +201,52 @@ fn start_updater(latest: &RepoRelease) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- parse_semver ---
+
+    #[test]
+    fn test_parse_semver_with_v_prefix() {
+        assert_eq!(parse_semver("v0.8.0"), Some((0, 8, 0)));
+    }
+
+    #[test]
+    fn test_parse_semver_without_prefix() {
+        assert_eq!(parse_semver("1.10.3"), Some((1, 10, 3)));
+    }
+
+    #[test]
+    fn test_parse_semver_invalid() {
+        assert_eq!(parse_semver("ERROR"), None);
+        assert_eq!(parse_semver("v1.2"), None);
+    }
+
+    // --- is_newer ---
+
+    #[test]
+    fn test_is_newer_detects_update() {
+        assert!(is_newer("v0.9.0", "v0.8.0"));
+    }
+
+    #[test]
+    fn test_is_newer_same_version() {
+        assert!(!is_newer("v0.8.0", "v0.8.0"));
+    }
+
+    #[test]
+    fn test_is_newer_older_does_not_trigger() {
+        assert!(!is_newer("v0.7.0", "v0.8.0"));
+    }
+
+    #[test]
+    fn test_is_newer_double_digit_minor() {
+        // string comparison would fail here: "v0.10.0" < "v0.9.0" lexicographically
+        assert!(is_newer("v0.10.0", "v0.9.0"));
+    }
+
+    #[test]
+    fn test_is_newer_major_bump() {
+        assert!(is_newer("v1.0.0", "v0.99.99"));
+    }
 
     // --- platform_identifier ---
 

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -31,7 +31,7 @@ pub async fn show_display_msg() {
     }
 
     if is_newer(&latest_version.tag_name, &current_version) {
-        start_updater(&latest_version);
+        start_updater(&latest_version).await;
     }
 }
 
@@ -54,12 +54,13 @@ fn is_newer(candidate: &str, baseline: &str) -> bool {
         _ => candidate > baseline,
     }
 }
-fn fetch_release(url: &str) -> Result<RepoRelease> {
-    let client = reqwest::blocking::Client::new();
+async fn fetch_release(url: &str) -> Result<RepoRelease> {
+    let client = reqwest::Client::new();
     let response = client
         .get(url)
         .header("User-Agent", "ninja-linter")
         .send()
+        .await
         .context("fallo al contactar la API de GitHub")?;
 
     if !response.status().is_success() {
@@ -68,11 +69,12 @@ fn fetch_release(url: &str) -> Result<RepoRelease> {
 
     response
         .json::<RepoRelease>()
+        .await
         .context("fallo al parsear el JSON de la release")
 }
 
 async fn check_repo() -> Result<RepoRelease> {
-    fetch_release("https://api.github.com/repos/IgnacioToledoDev/ninja-linter/releases/latest")
+    fetch_release("https://api.github.com/repos/IgnacioToledoDev/ninja-linter/releases/latest").await
 }
 
 async fn latest_version() -> RepoRelease {
@@ -114,21 +116,22 @@ fn find_asset_url(release: &RepoRelease) -> Result<String> {
         .with_context(|| format!("no se encontró un asset para la plataforma '{}'", platform))
 }
 
-fn download_to_temp(url: &str) -> Result<std::path::PathBuf> {
-    let client = reqwest::blocking::Client::new();
+async fn download_to_temp(url: &str) -> Result<std::path::PathBuf> {
+    let client = reqwest::Client::new();
     let resp = client
         .get(url)
         .header("User-Agent", "ninja-linter")
         .send()
+        .await
         .context("fallo al descargar el asset")?;
 
-    // TODO: Better handler errors this
     if !resp.status().is_success() {
         bail!("descarga falló con status {}", resp.status());
     }
 
     let bytes = resp
         .bytes()
+        .await
         .context("fallo al leer el cuerpo de la descarga")?;
 
     let tmp_path = std::env::temp_dir().join(format!("{}-update", "ninja-linter"));
@@ -148,22 +151,20 @@ fn download_to_temp(url: &str) -> Result<std::path::PathBuf> {
 }
 
 // TODO: refactor this
-fn start_updater(latest: &RepoRelease) {
+async fn start_updater(latest: &RepoRelease) {
     println!(
         "New version available: {} → {}. can you update (y/o)",
         env!("CARGO_PKG_VERSION"),
         latest.tag_name
     );
 
-    let mut user_res = String::new();
+    let user_res = tokio::task::block_in_place(|| {
+        let mut buf = String::new();
+        io::stdin().read_line(&mut buf).expect("Failed to read line");
+        buf
+    });
 
-    io::stdin()
-        .read_line(&mut user_res)
-        .expect("Failed to read line");
-
-    let expected_res = String::from("y");
-
-    if user_res.trim().to_lowercase() != expected_res {
+    if user_res.trim().to_lowercase() != "y" {
         return;
     }
 
@@ -175,7 +176,7 @@ fn start_updater(latest: &RepoRelease) {
         }
     };
 
-    let path = match download_to_temp(&asset_url) {
+    let path = match download_to_temp(&asset_url).await {
         Ok(p) => p,
         Err(e) => {
             println!("Cannot download update: {}", e);
@@ -371,9 +372,9 @@ mod tests {
 
     // --- fetch_release (HTTP mock) ---
 
-    #[test]
-    fn test_fetch_release_success() {
-        let mut server = mockito::Server::new();
+    #[tokio::test]
+    async fn test_fetch_release_success() {
+        let mut server = mockito::Server::new_async().await;
         let _mock = server
             .mock("GET", "/releases/latest")
             .with_status(200)
@@ -381,76 +382,85 @@ mod tests {
             .with_body(
                 r#"{"tag_name":"v2.0.0","assets":[{"name":"ninja-linter-linux-amd64","download_url":"https://example.com/bin"}]}"#,
             )
-            .create();
+            .create_async()
+            .await;
 
         let url = format!("{}/releases/latest", server.url());
-        let release = fetch_release(&url).unwrap();
+        let release = fetch_release(&url).await.unwrap();
         assert_eq!(release.tag_name, "v2.0.0");
         assert_eq!(release.assets.len(), 1);
         assert_eq!(release.assets[0].name, "ninja-linter-linux-amd64");
     }
 
-    #[test]
-    fn test_fetch_release_http_error_returns_err() {
-        let mut server = mockito::Server::new();
+    #[tokio::test]
+    async fn test_fetch_release_http_error_returns_err() {
+        let mut server = mockito::Server::new_async().await;
         let _mock = server
             .mock("GET", "/releases/latest")
             .with_status(404)
-            .create();
+            .create_async()
+            .await;
 
         let url = format!("{}/releases/latest", server.url());
-        assert!(fetch_release(&url).is_err());
+        assert!(fetch_release(&url).await.is_err());
     }
 
-    #[test]
-    fn test_fetch_release_server_error_returns_err() {
-        let mut server = mockito::Server::new();
+    #[tokio::test]
+    async fn test_fetch_release_server_error_returns_err() {
+        let mut server = mockito::Server::new_async().await;
         let _mock = server
             .mock("GET", "/releases/latest")
             .with_status(500)
-            .create();
+            .create_async()
+            .await;
 
         let url = format!("{}/releases/latest", server.url());
-        assert!(fetch_release(&url).is_err());
+        assert!(fetch_release(&url).await.is_err());
     }
 
-    #[test]
-    fn test_fetch_release_invalid_json_returns_err() {
-        let mut server = mockito::Server::new();
+    #[tokio::test]
+    async fn test_fetch_release_invalid_json_returns_err() {
+        let mut server = mockito::Server::new_async().await;
         let _mock = server
             .mock("GET", "/releases/latest")
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body("not json at all")
-            .create();
+            .create_async()
+            .await;
 
         let url = format!("{}/releases/latest", server.url());
-        assert!(fetch_release(&url).is_err());
+        assert!(fetch_release(&url).await.is_err());
     }
 
     // --- download_to_temp (HTTP mock) ---
 
-    #[test]
-    fn test_download_to_temp_success() {
-        let mut server = mockito::Server::new();
+    #[tokio::test]
+    async fn test_download_to_temp_success() {
+        let mut server = mockito::Server::new_async().await;
         let _mock = server
             .mock("GET", "/asset")
             .with_status(200)
             .with_body(b"fake-binary-content".as_ref())
-            .create();
+            .create_async()
+            .await;
 
         let url = format!("{}/asset", server.url());
-        let path = download_to_temp(&url).unwrap();
+        let path = download_to_temp(&url).await.unwrap();
         assert!(path.exists());
         let _ = std::fs::remove_file(&path);
     }
 
-    #[test]
-    fn test_download_to_temp_http_error_returns_err() {
-        let mut server = mockito::Server::new();
-        let _mock = server.mock("GET", "/asset").with_status(403).create();
+    #[tokio::test]
+    async fn test_download_to_temp_http_error_returns_err() {
+        let mut server = mockito::Server::new_async().await;
+        let _mock = server
+            .mock("GET", "/asset")
+            .with_status(403)
+            .create_async()
+            .await;
 
         let url = format!("{}/asset", server.url());
-        assert!(download_to_temp(&url).is_err());
+        assert!(download_to_temp(&url).await.is_err());
     }
 }

--- a/src/updater.rs
+++ b/src/updater.rs
@@ -14,7 +14,7 @@ struct RepoRelease {
 #[derive(Deserialize, Debug)]
 struct Asset {
     name: String,
-    download_url: String,
+    browser_download_url: String,
 }
 
 // ----------- CHECK VERSION -------------------
@@ -74,7 +74,8 @@ async fn fetch_release(url: &str) -> Result<RepoRelease> {
 }
 
 async fn check_repo() -> Result<RepoRelease> {
-    fetch_release("https://api.github.com/repos/IgnacioToledoDev/ninja-linter/releases/latest").await
+    fetch_release("https://api.github.com/repos/IgnacioToledoDev/ninja-linter/releases/latest")
+        .await
 }
 
 async fn latest_version() -> RepoRelease {
@@ -112,7 +113,7 @@ fn find_asset_url(release: &RepoRelease) -> Result<String> {
         .assets
         .iter()
         .find(|a| a.name.contains(platform))
-        .map(|a| a.download_url.clone())
+        .map(|a| a.browser_download_url.clone())
         .with_context(|| format!("no se encontró un asset para la plataforma '{}'", platform))
 }
 
@@ -160,7 +161,9 @@ async fn start_updater(latest: &RepoRelease) {
 
     let user_res = tokio::task::block_in_place(|| {
         let mut buf = String::new();
-        io::stdin().read_line(&mut buf).expect("Failed to read line");
+        io::stdin()
+            .read_line(&mut buf)
+            .expect("Failed to read line");
         buf
     });
 
@@ -277,7 +280,7 @@ mod tests {
             tag_name: String::from("v1.0.0"),
             assets: vec![Asset {
                 name: format!("ninja-linter-{}.tar.gz", platform),
-                download_url: String::from("https://example.com/asset"),
+                browser_download_url: String::from("https://example.com/asset"),
             }],
         };
         let url = find_asset_url(&release).unwrap();
@@ -290,7 +293,7 @@ mod tests {
             tag_name: String::from("v1.0.0"),
             assets: vec![Asset {
                 name: String::from("ninja-linter-unknown-platform.tar.gz"),
-                download_url: String::from("https://example.com/asset"),
+                browser_download_url: String::from("https://example.com/asset"),
             }],
         };
         assert!(find_asset_url(&release).is_err());
@@ -313,11 +316,11 @@ mod tests {
             assets: vec![
                 Asset {
                     name: String::from("ninja-linter-other-platform.tar.gz"),
-                    download_url: String::from("https://example.com/wrong"),
+                    browser_download_url: String::from("https://example.com/wrong"),
                 },
                 Asset {
                     name: format!("ninja-linter-{}.tar.gz", platform),
-                    download_url: String::from("https://example.com/correct"),
+                    browser_download_url: String::from("https://example.com/correct"),
                 },
             ],
         };
@@ -334,7 +337,7 @@ mod tests {
             "assets": [
                 {
                     "name": "ninja-linter-linux-amd64",
-                    "download_url": "https://github.com/example/releases/download/v1.2.3/ninja-linter-linux-amd64"
+                    "browser_download_url": "https://github.com/example/releases/download/v1.2.3/ninja-linter-linux-amd64"
                 }
             ]
         }"#;
@@ -343,7 +346,7 @@ mod tests {
         assert_eq!(release.assets.len(), 1);
         assert_eq!(release.assets[0].name, "ninja-linter-linux-amd64");
         assert_eq!(
-            release.assets[0].download_url,
+            release.assets[0].browser_download_url,
             "https://github.com/example/releases/download/v1.2.3/ninja-linter-linux-amd64"
         );
     }
@@ -380,7 +383,7 @@ mod tests {
             .with_status(200)
             .with_header("content-type", "application/json")
             .with_body(
-                r#"{"tag_name":"v2.0.0","assets":[{"name":"ninja-linter-linux-amd64","download_url":"https://example.com/bin"}]}"#,
+                r#"{"tag_name":"v2.0.0","assets":[{"name":"ninja-linter-linux-amd64","browser_download_url":"https://example.com/bin"}]}"#,
             )
             .create_async()
             .await;


### PR DESCRIPTION
## Summary

- Adds 24h cooldown for the new-version prompt — shows on first run, then once per day
- Stores next-check timestamp in RFC3339 via `updated_check_at` in config
- Adds `chrono` dependency for timestamp handling

## Bugs fixed

- `has_updated_check_at` returned `is_empty()` (inverted logic)
- `get_updated_check_at` used format `%d/%m/%Y %H:%M:%S` with `DateTime::parse_from_str` — no timezone → always panicked
- `set_updated_check_at` stored via `.to_string()` (incompatible with the parser format)
- `save_timestap` branched on inverted flag and used `now < next_check` (backwards comparison)
- Missing `#[serde(default)]` on `updated_check_at` broke deserialization of old config files

## Test plan

- [ ] `cargo test` — 71 tests pass
- [ ] First run shows update prompt when newer version exists
- [ ] Second run within 24h suppresses prompt
- [ ] Run after cooldown expiry shows prompt again